### PR TITLE
Update server_status action alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ st2 run packs.install packs=st2-chatops-aliases repo_url=armab/st2-chatops-alias
 ## Available ChatOps commands
 Full list of available commands (with real use case Slack screenshots):
 * [`!ansible <command>`](https://i.imgur.com/9xEgfP6.png) - Run ansible command on local machine
-* [`!status {{hosts}}`](http://i.imgur.com/fak6ZP7.png) - Show status for hosts (ansible ping module)
+* [`!status <hosts>`](https://i.imgur.com/ZOZgGnz.png) - Show status for hosts (ansible ping module)
 * [`!show nginx stats on <hosts>`](https://i.imgur.com/Wsvdx3W.png) - Show sorted http status codes from nginx on hosts
 * [`!show mysql processlist <hosts=db>`](https://i.imgur.com/RxePho1.png) - Show MySQL processlist
 * [`!service restart {{service_name}} on {{hosts}}`](http://i.imgur.com/xVyl6xW.png) - Restart service on remote hosts

--- a/aliases/server_status.yaml
+++ b/aliases/server_status.yaml
@@ -6,4 +6,23 @@ name: chatops.ansible_server_status
 action_ref: st2-chatops-aliases.server_status
 description: Show status for hosts (ansible ping module)
 formats:
-  - "status {{hosts}}"
+  - display: "status <hosts>"
+    representation:
+      - "status {{ hosts }}"
+      - "ping {{ hosts }}"
+result:
+  format: |
+    Here is your status for `{{ execution.parameters.hosts }}` host(s): {~}
+    ```{{ execution.result.stdout }}```
+  extra:
+    slack:
+      color: "{% if execution.result.succeeded %}good{% else %}danger{% endif %}"
+      fields:
+        - title: Alive
+          value: "{{ execution.result.stdout|regex_replace('(?!SUCCESS).', '')|wordcount }}"
+          short: true
+        - title: Dead
+          value: "{{ execution.result.stdout|regex_replace('(?!UNREACHABLE).', '')|wordcount }}"
+          short: true
+      footer: "{{ execution.id }}"
+      footer_icon: "https://stackstorm.com/wp/wp-content/uploads/2015/01/favicon.png"


### PR DESCRIPTION
> Part of StackStorm/showcase-ansible-chatops#6

So far it's richest use of [Slack API](https://api.slack.com/docs/message-attachments) for message attachments.

![](https://i.imgur.com/ZOZgGnz.png)

^^ @LindsayHill Some nice looking example with `alive`/`dead` servers.
