### PR TITLE
Update service_restart action alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Full list of available commands (with real use case Slack screenshots):
 * [`!status <hosts>`](https://i.imgur.com/ZOZgGnz.png) - Show status for hosts (ansible ping module)
 * [`!show nginx stats on <hosts>`](https://i.imgur.com/Wsvdx3W.png) - Show sorted http status codes from nginx on hosts
 * [`!show mysql processlist <hosts=db>`](https://i.imgur.com/RxePho1.png) - Show MySQL processlist
-* [`!service restart {{service_name}} on {{hosts}}`](http://i.imgur.com/xVyl6xW.png) - Restart service on remote hosts
+* [`!service restart <service_name> on <hosts>`](https://i.imgur.com/rNsHdtK.png) - Restart service on remote hosts
 * [`!show version <package> on <hosts>`](https://i.imgur.com/M8hTv9W.png) - Show package versions on hosts
 * [`!update {{package}} on {{hosts}}`](http://i.imgur.com/IT2EDcn.png) - Update package on remote hosts
 * [`!cowsay <message>`](https://i.imgur.com/mCYHFM6.png) - Draws a cow that says what you want

--- a/aliases/service_restart.yaml
+++ b/aliases/service_restart.yaml
@@ -6,4 +6,27 @@ name: chatops.ansible_service_restart
 action_ref: st2-chatops-aliases.service_restart
 description: Restart service on remote hosts
 formats:
-  - "service restart {{service_name}} on {{hosts}}"
+  - display: "service restart <service_name> on <hosts>"
+    representation:
+      - "service restart {{ service_name }} on {{ hosts }}"
+result:
+  format: |
+    Service restart `{{ execution.parameters.service_name }}` on `{{ execution.parameters.hosts }}` host(s): {~}
+    {% if execution.result.stderr %}
+    *Exit Status*: `{{ execution.result.return_code }}`
+    *Stderr:* ```{{ execution.result.stderr }}```
+    *Stdout:*
+    {% endif %}
+    ```{{ execution.result.stdout }}```
+  extra:
+    slack:
+      color: "{% if execution.result.succeeded %}good{% else %}danger{% endif %}"
+      fields:
+        - title: Restarted
+          value: "{{ execution.result.stdout|regex_replace('(?!SUCCESS).', '')|wordcount }}"
+          short: true
+        - title: Failed
+          value: "{{ execution.result.stdout|regex_replace('(?!(FAILED|UNREACHABLE)!).', '')|wordcount }}"
+          short: true
+      footer: "{{ execution.id }}"
+      footer_icon: "https://stackstorm.com/wp/wp-content/uploads/2015/01/favicon.png"


### PR DESCRIPTION
> Part of StackStorm/showcase-ansible-chatops#6

Using [Slack API](https://api.slack.com/docs/message-attachments) for message attachments and some [Jinja hackery](https://docs.stackstorm.com/reference/jinja_filters.html#regex-replace) to determine number of `failed`/`succeeded` nodes.
### Success

![](https://i.imgur.com/rNsHdtK.png)
### Failure

![](https://i.imgur.com/SFoy71E.png)
